### PR TITLE
compare value

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ public readonly partial struct Hp : IEquatable<Hp> , IComparable<Hp>
     public static Hp operator /(in Hp x, in int y) => new Hp(checked((int)(x.value / y)));
 
     // UnitGenerateOptions.Comparable
-    public int CompareTo(Hp other) => value.CompareTo(other);
+    public int CompareTo(Hp other) => value.CompareTo(other.value);
     public static bool operator >(in Hp x, in Hp y) => x.value > y.value;
     public static bool operator <(in Hp x, in Hp y) => x.value < y.value;
     public static bool operator >=(in Hp x, in Hp y) => x.value >= y.value;
@@ -319,7 +319,7 @@ public static T operator /(in T x, in U y) => new T(checked((U)(x.value / y)));
 Implements `IComparable<T>` and `>`, `<`, `>=`, `<=` operators.
 
 ```csharp
-public U CompareTo(T other) => value.CompareTo(other);
+public U CompareTo(T other) => value.CompareTo(other.value);
 public static bool operator >(in T x, in T y) => x.value > y.value;
 public static bool operator <(in T x, in T y) => x.value < y.value;
 public static bool operator >=(in T x, in T y) => x.value >= y.value;

--- a/src/UnitGenerator/CodeTemplate.cs
+++ b/src/UnitGenerator/CodeTemplate.cs
@@ -290,7 +290,7 @@ namespace UnitGenerator
  if (HasFlag(UnitGenerateOptions.Comparable)) { 
             this.Write(" \r\n        // UnitGenerateOptions.Comparable\r\n\r\n        public int CompareTo(");
             this.Write(this.ToStringHelper.ToStringWithCulture(Name));
-            this.Write(" other)\r\n        {\r\n            return value.CompareTo(other);\r\n        }\r\n      " +
+            this.Write(" other)\r\n        {\r\n            return value.CompareTo(other.value);\r\n        }\r\n      " +
                     "  \r\n        public static bool operator >(in ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Name));
             this.Write(" x, in ");

--- a/src/UnitGenerator/CodeTemplate.tt
+++ b/src/UnitGenerator/CodeTemplate.tt
@@ -255,7 +255,7 @@ namespace <#= Namespace #>
 
         public int CompareTo(<#= Name #> other)
         {
-            return value.CompareTo(other);
+            return value.CompareTo(other.value);
         }
         
         public static bool operator >(in <#= Name #> x, in <#= Name #> y)


### PR DESCRIPTION
`UnitGenerateOptions.Comparable`を指定して`UnitGenerateOptions.ImplicitOperator`を指定しなかった場合でも比較できるようにしました。