### PR TITLE
UnitOfAttribute のフルネームを記述した場合もコード生成の対象とする

### DIFF
--- a/src/UnitGenerator/SourceGenerator.cs
+++ b/src/UnitGenerator/SourceGenerator.cs
@@ -122,7 +122,7 @@ namespace UnitGenerator
             {
                 if (syntaxNode is StructDeclarationSyntax s && s.AttributeLists.Count > 0)
                 {
-                    var attr = s.AttributeLists.SelectMany(x => x.Attributes).FirstOrDefault(x => x.Name.ToString() is "UnitOf" or "UnitOfAttribute");
+                    var attr = s.AttributeLists.SelectMany(x => x.Attributes).FirstOrDefault(x => x.Name.ToString() is "UnitOf" or "UnitOfAttribute" or "UnitGenerator.UnitOf" or "UnitGenerator.UnitOfAttribute");
                     if (attr != null)
                     {
                         Targets.Add((s, attr));


### PR DESCRIPTION
下記のように名前空間の指定まで含んだ `UnitOfAttribute` を書いた際に，コード生成の対象にならない問題を修正しました．

```csharp
[UnitGenerator.UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperator | UnitGenerateOptions.ValueArithmeticOperator | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter)]
public readonly partial struct T
{
    private partial void Validate()
    {
        _ = AsPrimitive();
    }
}
```

`AttributeSyntax.Name.ToString()` は

- `[UnitOf(...)]` と書かれたときは `"UnitOf"`
- `[UnitGenerator.UnitOf(...)]` と書かれたときは `"UnitGenerator.UnitOf"`

を返すため，

- `"UnitGenerator.UnitOf"`
- `"UnitGenerator.UnitOfAttribute"`

もマッチするように条件を追加しました．