### PR TITLE
Remove explicit reference of `System.Core`

### DIFF
--- a/src/UnitGenerator/CodeTemplate.tt
+++ b/src/UnitGenerator/CodeTemplate.tt
@@ -1,5 +1,4 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" linePragmas="false" #>
-<#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>

--- a/src/UnitGenerator/UnitOfAttributeTemplate.tt
+++ b/src/UnitGenerator/UnitOfAttributeTemplate.tt
@@ -1,5 +1,4 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" linePragmas="false" #>
-<#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>


### PR DESCRIPTION
There are  explicit references of `System.Core` in the asembly directive in the T4 template, but this probably does not need .

The problem with this; 

I don't understand the details, but under macOS + Rider, I get the following error, which is a bit annoying.
( however, the build succeeds. 🤔 

![スクリーンショット 2023-08-03 14 31 34](https://github.com/Cysharp/UnitGenerator/assets/727159/86ee204d-f67a-408b-acdf-e0956cc6fccd)
