### PR TITLE
Add options to define arithmetic operators separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,19 +114,25 @@ You can configure with `UnitGenerateOptions`, which method to implement.
 enum UnitGenerateOptions
 {
     None = 0,
-    ImplicitOperator = 1,
-    ParseMethod = 2,
-    MinMaxMethod = 4,
-    ArithmeticOperator = 8,
-    ValueArithmeticOperator = 16,
-    Comparable = 32,
-    Validate = 64,
-    JsonConverter = 128,
-    MessagePackFormatter = 256,
-    DapperTypeHandler = 512,
-    EntityFrameworkValueConverter = 1024,
-    WithoutComparisonOperator = 2048,
-    JsonConverterDictionaryKeySupport = 4096
+    ImplicitOperator = 1,        
+    ParseMethod = 1 << 1,
+    MinMaxMethod = 1 << 2,
+    ArithmeticOperator = 1 << 3,
+    ValueArithmeticOperator = 1 << 4,
+    Comparable = 1 << 5,
+    Validate = 1 << 6,
+    JsonConverter = 1 << 7,
+    MessagePackFormatter = 1 << 8,
+    DapperTypeHandler = 1 << 9,
+    EntityFrameworkValueConverter = 1 << 10,
+    WithoutComparisonOperator = 1 << 11,
+    JsonConverterDictionaryKeySupport = 1 << 12,
+    ArithmeticOperatorAddition = 1 << 13,
+    ArithmeticOperatorSubtraction = 1 << 13,
+    ArithmeticOperatorMultiply = 1 << 14,
+    ArithmeticOperatorDivision = 1 << 15,
+    ValueArithmeticOperatorAddition = 1 << 16,
+    ValueArithmeticOperatorSubtraction = 1 << 17
 }
 ```
 
@@ -324,6 +330,12 @@ public static T operator *(in T x, in T y) => new T(checked((U)(x.value * y.valu
 public static T operator /(in T x, in T y) => new T(checked((U)(x.value / y.value)));
 ```
 
+If you want to enable only certain arithmetic operators, you can use a combination of the following options:
+- `ArithmeticOperatorAddition` : Only add `+`
+- `ArithmeticOperatorSubtraction`: Only add `-` 
+- `ArithmeticOperatorMultiply`: Only add `*`
+- `ArithmeticOperatorDivision`: Only add `/`
+
 ### ValueArithmeticOperator
 
 ```csharp
@@ -334,6 +346,10 @@ public static T operator -(in T x, in U y) => new T(checked((U)(x.value - y)));
 public static T operator *(in T x, in U y) => new T(checked((U)(x.value * y)));
 public static T operator /(in T x, in U y) => new T(checked((U)(x.value / y)));
 ```
+
+If you want to enable only certain arithmetic operators, you can use a combination of the following options:
+- `ValueArithmeticOperatorAddition` : Only add `++`
+- `ValueArithmeticOperatorSubtraction`: Only add `--`
 
 ### Comparable
 

--- a/sandbox/ConsoleApp/AllPrimitives.cs
+++ b/sandbox/ConsoleApp/AllPrimitives.cs
@@ -26,6 +26,15 @@ namespace ConsoleApp
             _ = AsPrimitive();
         }
     }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperator | UnitGenerateOptions.ValueArithmeticOperator | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport | UnitGenerateOptions.ImplicitOperator)]
+    public readonly partial struct A2
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
 
     [UnitOf(typeof(uint), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperator | UnitGenerateOptions.ValueArithmeticOperator | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
     public readonly partial struct B
@@ -101,6 +110,60 @@ namespace ConsoleApp
 
     [UnitOf(typeof(float), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperator | UnitGenerateOptions.ValueArithmeticOperator | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
     public readonly partial struct J
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperatorAddition | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
+    public readonly partial struct AAdd
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperatorSubtraction | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
+    public readonly partial struct ASub
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperatorMultiply | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
+    public readonly partial struct AMul
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ArithmeticOperatorDivision | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
+    public readonly partial struct ADiv
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ValueArithmeticOperatorAddition | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
+    public readonly partial struct VAAdd
+    {
+        private partial void Validate()
+        {
+            _ = AsPrimitive();
+        }
+    }
+    
+    [UnitOf(typeof(int), UnitGenerateOptions.ParseMethod | UnitGenerateOptions.MinMaxMethod | UnitGenerateOptions.ValueArithmeticOperatorSubtraction | UnitGenerateOptions.Comparable | UnitGenerateOptions.Validate | UnitGenerateOptions.JsonConverter | UnitGenerateOptions.MessagePackFormatter | UnitGenerateOptions.DapperTypeHandler | UnitGenerateOptions.EntityFrameworkValueConverter | UnitGenerateOptions.JsonConverterDictionaryKeySupport)]
+    public readonly partial struct VASub
     {
         private partial void Validate()
         {

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/UnitOfAttribute.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/UnitOfAttribute.cs
@@ -26,18 +26,24 @@ namespace UnitGenerator
     internal enum UnitGenerateOptions
     {
         None = 0,
-        ImplicitOperator = 1,
-        ParseMethod = 2,
-        MinMaxMethod = 4,
-        ArithmeticOperator = 8,
-        ValueArithmeticOperator = 16,
-        Comparable = 32,
-        Validate = 64,
-        JsonConverter = 128,
-        MessagePackFormatter = 256,
-        DapperTypeHandler = 512,
-        EntityFrameworkValueConverter = 1024,
-        WithoutComparisonOperator = 2048,
-        JsonConverterDictionaryKeySupport = 4096
+        ImplicitOperator = 1,    
+        ParseMethod = 1 << 1,
+        MinMaxMethod = 1 << 2,
+        ArithmeticOperator = 1 << 3,
+        ValueArithmeticOperator = 1 << 4,
+        Comparable = 1 << 5,
+        Validate = 1 << 6,
+        JsonConverter = 1 << 7,
+        MessagePackFormatter = 1 << 8,
+        DapperTypeHandler = 1 << 9,
+        EntityFrameworkValueConverter = 1 << 10,
+        WithoutComparisonOperator = 1 << 11,
+        JsonConverterDictionaryKeySupport = 1 << 12,
+        ArithmeticOperatorAddition = 1 << 13,
+        ArithmeticOperatorSubtraction = 1 << 13,
+        ArithmeticOperatorMultiply = 1 << 14,
+        ArithmeticOperatorDivision = 1 << 15,
+        ValueArithmeticOperatorAddition = 1 << 16,
+        ValueArithmeticOperatorSubtraction = 1 << 17    
     }
 }

--- a/src/UnitGenerator/SourceGenerator.cs
+++ b/src/UnitGenerator/SourceGenerator.cs
@@ -133,19 +133,25 @@ namespace UnitGenerator
     internal enum UnitGenerateOptions
     {
         None = 0,
-        ImplicitOperator = 1,
-        ParseMethod = 2,
-        MinMaxMethod = 4,
-        ArithmeticOperator = 8,
-        ValueArithmeticOperator = 16,
-        Comparable = 32,
-        Validate = 64,
-        JsonConverter = 128,
-        MessagePackFormatter = 256,
-        DapperTypeHandler = 512,
-        EntityFrameworkValueConverter = 1024,
-        WithoutComparisonOperator = 2048,
-        JsonConverterDictionaryKeySupport = 4096
+        ImplicitOperator = 1,    
+        ParseMethod = 1 << 1,
+        MinMaxMethod = 1 << 2,
+        ArithmeticOperator = 1 << 3,
+        ValueArithmeticOperator = 1 << 4,
+        Comparable = 1 << 5,
+        Validate = 1 << 6,
+        JsonConverter = 1 << 7,
+        MessagePackFormatter = 1 << 8,
+        DapperTypeHandler = 1 << 9,
+        EntityFrameworkValueConverter = 1 << 10,
+        WithoutComparisonOperator = 1 << 11,
+        JsonConverterDictionaryKeySupport = 1 << 12,
+        ArithmeticOperatorAddition = 1 << 13,
+        ArithmeticOperatorSubtraction = 1 << 13,
+        ArithmeticOperatorMultiply = 1 << 14,
+        ArithmeticOperatorDivision = 1 << 15,
+        ValueArithmeticOperatorAddition = 1 << 16,
+        ValueArithmeticOperatorSubtraction = 1 << 17    
     }
 }
 """;
@@ -439,11 +445,13 @@ namespace {{ns}}
  """);
             }
 
-            if (prop.HasFlag(UnitGenerateOptions.ArithmeticOperator))
+            if (prop.HasFlag(UnitGenerateOptions.ArithmeticOperator) ||
+                prop.HasFlag(UnitGenerateOptions.ArithmeticOperatorAddition) ||
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator) ||
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperatorAddition))
             {
                 sb.AppendLine($$"""
-        // UnitGenerateOptions.ArithmeticOperator
-
+        // UnitGenerateOptions.ArithmeticOperator (Addition)
         public static {{unitTypeName}} operator +(in {{unitTypeName}} x, in {{unitTypeName}} y)
         {
             checked
@@ -451,7 +459,17 @@ namespace {{ns}}
                 return new {{unitTypeName}}(({{innerTypeName}})(x.value + y.value));
             }
         }
-
+                                
+""");
+            }
+            
+            if (prop.HasFlag(UnitGenerateOptions.ArithmeticOperator) ||
+                prop.HasFlag(UnitGenerateOptions.ArithmeticOperatorSubtraction) ||
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator) ||
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperatorSubtraction))
+            {
+                sb.AppendLine($$"""
+        // UnitGenerateOptions.ArithmeticOperator (Subtraction)
         public static {{unitTypeName}} operator -(in {{unitTypeName}} x, in {{unitTypeName}} y)
         {
             checked
@@ -459,7 +477,16 @@ namespace {{ns}}
                 return new {{unitTypeName}}(({{innerTypeName}})(x.value - y.value));
             }
         }
-
+                                
+""");
+            }
+            
+            if (prop.HasFlag(UnitGenerateOptions.ArithmeticOperator) ||
+                prop.HasFlag(UnitGenerateOptions.ArithmeticOperatorMultiply) ||
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator))
+            {
+                sb.AppendLine($$"""
+        // UnitGenerateOptions.ArithmeticOperator (Multiply)
         public static {{unitTypeName}} operator *(in {{unitTypeName}} x, in {{unitTypeName}} y)
         {
             checked
@@ -467,7 +494,16 @@ namespace {{ns}}
                 return new {{unitTypeName}}(({{innerTypeName}})(x.value * y.value));
             }
         }
-
+                                
+""");
+            }
+            
+            if (prop.HasFlag(UnitGenerateOptions.ArithmeticOperator) ||
+                prop.HasFlag(UnitGenerateOptions.ArithmeticOperatorDivision) ||
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator))
+            {
+                sb.AppendLine($$"""
+        // UnitGenerateOptions.ArithmeticOperator (Division)
         public static {{unitTypeName}} operator /(in {{unitTypeName}} x, in {{unitTypeName}} y)
         {
             checked
@@ -479,11 +515,11 @@ namespace {{ns}}
 """);
             }
 
-            if (prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator))
+            if (prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator) || 
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperatorAddition))
             {
                 sb.AppendLine($$"""
-        // UnitGenerateOptions.ValueArithmeticOperator
-
+        // UnitGenerateOptions.ValueArithmeticOperator (Addition)
         public static {{unitTypeName}} operator ++(in {{unitTypeName}} x)
         {
             checked
@@ -492,43 +528,19 @@ namespace {{ns}}
             }
         }
 
+""");
+            }
+
+            if (prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperator) || 
+                prop.HasFlag(UnitGenerateOptions.ValueArithmeticOperatorSubtraction))
+            {
+                sb.AppendLine($$"""
+        // UnitGenerateOptions.ValueArithmeticOperator (Subtraction)
         public static {{unitTypeName}} operator --(in {{unitTypeName}} x)
         {
             checked
             {
                 return new {{unitTypeName}}(({{innerTypeName}})(x.value - 1));
-            }
-        }
-
-        public static {{unitTypeName}} operator +(in {{unitTypeName}} x, in {{innerTypeName}} y)
-        {
-            checked
-            {
-                return new {{unitTypeName}}(({{innerTypeName}})(x.value + y));
-            }
-        }
-
-        public static {{unitTypeName}} operator -(in {{unitTypeName}} x, in {{innerTypeName}} y)
-        {
-            checked
-            {
-                return new {{unitTypeName}}(({{innerTypeName}})(x.value - y));
-            }
-        }
-
-        public static {{unitTypeName}} operator *(in {{unitTypeName}} x, in {{innerTypeName}} y)
-        {
-            checked
-            {
-                return new {{unitTypeName}}(({{innerTypeName}})(x.value * y));
-            }
-        }
-
-        public static {{unitTypeName}} operator /(in {{unitTypeName}} x, in {{innerTypeName}} y)
-        {
-            checked
-            {
-                return new {{unitTypeName}}(({{innerTypeName}})(x.value / y));
             }
         }
 

--- a/src/UnitGenerator/UnitGenerateOptions.cs
+++ b/src/UnitGenerator/UnitGenerateOptions.cs
@@ -7,18 +7,24 @@ namespace UnitGenerator
     internal enum UnitGenerateOptions
     {
         None = 0,
-        ImplicitOperator = 1,
-        ParseMethod = 2,
-        MinMaxMethod = 4,
-        ArithmeticOperator = 8,
-        ValueArithmeticOperator = 16,
-        Comparable = 32,
-        Validate = 64,
-        JsonConverter = 128,
-        MessagePackFormatter = 256,
-        DapperTypeHandler = 512,
-        EntityFrameworkValueConverter = 1024,
-        WithoutComparisonOperator = 2048,
-        JsonConverterDictionaryKeySupport = 4096
+        ImplicitOperator = 1,        
+        ParseMethod = 1 << 1,
+        MinMaxMethod = 1 << 2,
+        ArithmeticOperator = 1 << 3,
+        ValueArithmeticOperator = 1 << 4,
+        Comparable = 1 << 5,
+        Validate = 1 << 6,
+        JsonConverter = 1 << 7,
+        MessagePackFormatter = 1 << 8,
+        DapperTypeHandler = 1 << 9,
+        EntityFrameworkValueConverter = 1 << 10,
+        WithoutComparisonOperator = 1 << 11,
+        JsonConverterDictionaryKeySupport = 1 << 12,
+        ArithmeticOperatorAddition = 1 << 13,
+        ArithmeticOperatorSubtraction = 1 << 13,
+        ArithmeticOperatorMultiply = 1 << 14,
+        ArithmeticOperatorDivision = 1 << 15,
+        ValueArithmeticOperatorAddition = 1 << 16,
+        ValueArithmeticOperatorSubtraction = 1 << 17
     }
 }


### PR DESCRIPTION
#24 

Added several options to allow +, -, *, / , operator to be defined separately.


|                                    | +            | -            | *            | /            | ++           | --           | 
| ---------------------------------- | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | 
| ArithmeticOperator                 |  :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |              |              | 
| ValueArithmeticOperator            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | 
| ArithmeticOperatorAddition         | :heavy_check_mark: |              |              |              |              |              | 
| ArithmeticOperatorSubtarction      |              | :heavy_check_mark: |              |              |              |              | 
| ArithmeticOperatorMultiply         |              |              | :heavy_check_mark: |              |              |              | 
| ArithmeticOperatorDivision         |              |              |              | :heavy_check_mark: |              |              | 
| ValueArithmeticOperatorAddition    | :heavy_check_mark: |              |              |              | :heavy_check_mark: |              | 
| ValueArithmeticOperatorSubtraction |              | :heavy_check_mark: |              |              |              | :heavy_check_mark: | 