### PR TITLE
Use Cysharp/Actions/setup-dotnet default version

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -15,8 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: |
-            5.0.x
-            6.0.x
       - run: dotnet build -c Debug


### PR DESCRIPTION
## tl;dr;

It support both .NET 6,7 and 8. No need specify version.

UnitGenerator already no need .NET 5.0