### PR TITLE
Add IComparable on 'UnitGenerateOptions.Comparable | UnitGenerateOptions.WithoutComparisonOperator'

### DIFF
--- a/src/UnitGenerator/SourceGenerator.cs
+++ b/src/UnitGenerator/SourceGenerator.cs
@@ -276,11 +276,13 @@ namespace {{ns}}
     readonly partial struct {{unitTypeName}} 
         : IEquatable<{{unitTypeName}}>
 """);
-            if (prop.HasFlag(UnitGenerateOptions.Comparable) && 
-                !prop.HasFlag(UnitGenerateOptions.WithoutComparisonOperator))
+            if (prop.HasFlag(UnitGenerateOptions.Comparable))
             {
                 anyPlatformInterfaces.Add($"IComparable<{unitTypeName}>");
-                net7Interfaces.Add($"IComparisonOperators<{unitTypeName}, {unitTypeName}, bool>");
+                if (!prop.HasFlag(UnitGenerateOptions.WithoutComparisonOperator))
+                {
+                    net7Interfaces.Add($"IComparisonOperators<{unitTypeName}, {unitTypeName}, bool>");
+                }
             }
             if (prop.HasFormattableInterface())
             {


### PR DESCRIPTION
In latest version, on specifying `UnitGenerateOptions.Comparable | UnitGenerateOptions.WithoutComparisonOperator`, interface `IComparable<T>` is not added, even if `CompareTo()` would be generated.

If intentionally supress it, I apologize for my lack of understanding.