### PR TITLE
Make it work with 'UnitOf<Ulid>'

### DIFF
--- a/src/UnitGenerator/SourceGenerator.cs
+++ b/src/UnitGenerator/SourceGenerator.cs
@@ -1357,7 +1357,7 @@ namespace {{ns}}
 
         class SyntaxReceiver : ISyntaxReceiver
         {
-            public List<(StructDeclarationSyntax type, AttributeSyntax attr, PredefinedTypeSyntax? targetType)> Targets { get; } = new();
+            public List<(StructDeclarationSyntax type, AttributeSyntax attr, TypeSyntax? targetType)> Targets { get; } = new();
 
             public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
             {
@@ -1372,7 +1372,7 @@ namespace {{ns}}
                                     SimpleNameSyntax name => name.Identifier.Text,
                                     _ => attribute.Name.ToString(),
                                 }
-                                let targetType = attribute.Name is GenericNameSyntax gName ? gName.TypeArgumentList.ChildNodes().FirstOrDefault() as PredefinedTypeSyntax : null
+                                let targetType = attribute.Name is GenericNameSyntax gName ? gName.TypeArgumentList.ChildNodes().FirstOrDefault() as TypeSyntax : null
                                 where attributeName is "UnitOf" or "UnitOfAttribute"
                                 select new { attribute, targetType }).FirstOrDefault();
 


### PR DESCRIPTION
- `UnitOf(typeof(Ulid), ...)` works, but `UnitOf<Ulid>(...)` does not work in lastest version.
- [var innerTypeName = prop.TypeName;](https://github.com/Cysharp/UnitGenerator/blob/3ac1cc815c453e65c0d6142afe4e31db35877fcf/src/UnitGenerator/SourceGenerator.cs#L211) throws due to `props.Type` null.
    - In [SyntaxReceiver.OnVisitSyntaxNode()](https://github.com/Cysharp/UnitGenerator/blob/3ac1cc815c453e65c0d6142afe4e31db35877fcf/src/UnitGenerator/SourceGenerator.cs#L1375), `UnitOf<Ulid>` appears as not `PredefinedTypeSyntax`, but `IdentifierNameSyntax`