### PR TITLE
Support Parse/TryParse for Guid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ src/MasterMemory.UnityClient/Temp/*
 # OTHER
 nuget/tools/*
 *.nupkg
+.idea
 
 .vs
 

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.A.g.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.A.g.cs
@@ -21,6 +21,27 @@ namespace FileGenerate
         , IUtf8SpanFormattable
 #endif
     {
+        class AsParsable<T> : IParsable<int> where T : IParsable<int>
+        {
+            public static int Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsSpanParsable<T> : ISpanParsable<int> where T : ISpanParsable<int>
+        {
+            public static int Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        
+            public static int Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsUtf8SpanParsable<T> : IUtf8SpanParsable<int> where T : IUtf8SpanParsable<int>
+        {
+            public static int Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => T.Parse(utf8Text, provider);
+            public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out int result) => T.TryParse(utf8Text, provider, out result);
+        }
+
         readonly int value;
 
         public int AsPrimitive() => value;
@@ -82,11 +103,11 @@ namespace FileGenerate
 
 #if NET6_0_OR_GREATER
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => 
-            ((ISpanFormattable)value).TryFormat(destination, out charsWritten, format, provider);
+            value.TryFormat(destination, out charsWritten, format, provider);
 #endif
 #if NET8_0_OR_GREATER        
         public bool TryFormat (Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider) =>
-            ((IUtf8SpanFormattable)value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+            value.TryFormat(utf8Destination, out bytesWritten, format, provider);
 #endif
 
         // Default

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.Aa.g.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.Aa.g.cs
@@ -21,6 +21,27 @@ namespace FileGenerate
         , IUtf8SpanFormattable
 #endif
     {
+        class AsParsable<T> : IParsable<int> where T : IParsable<int>
+        {
+            public static int Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsSpanParsable<T> : ISpanParsable<int> where T : ISpanParsable<int>
+        {
+            public static int Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        
+            public static int Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsUtf8SpanParsable<T> : IUtf8SpanParsable<int> where T : IUtf8SpanParsable<int>
+        {
+            public static int Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => T.Parse(utf8Text, provider);
+            public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out int result) => T.TryParse(utf8Text, provider, out result);
+        }
+
         readonly int value;
 
         public int AsPrimitive() => value;
@@ -82,11 +103,11 @@ namespace FileGenerate
 
 #if NET6_0_OR_GREATER
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => 
-            ((ISpanFormattable)value).TryFormat(destination, out charsWritten, format, provider);
+            value.TryFormat(destination, out charsWritten, format, provider);
 #endif
 #if NET8_0_OR_GREATER        
         public bool TryFormat (Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider) =>
-            ((IUtf8SpanFormattable)value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+            value.TryFormat(utf8Destination, out bytesWritten, format, provider);
 #endif
 
         // Default

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.B.g.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.B.g.cs
@@ -16,6 +16,21 @@ namespace FileGenerate
         , IEqualityOperators<B, B, bool>
 #endif
     {
+        class AsParsable<T> : IParsable<string> where T : IParsable<string>
+        {
+            public static string Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out string result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsSpanParsable<T> : ISpanParsable<string> where T : ISpanParsable<string>
+        {
+            public static string Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out string result) => T.TryParse(s, provider, out result);
+        
+            public static string Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out string result) => T.TryParse(s, provider, out result);
+        }
+
         readonly string value;
 
         public string AsPrimitive() => value;

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.Bb.g.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.Bb.g.cs
@@ -16,6 +16,21 @@ namespace FileGenerate
         , IEqualityOperators<Bb, Bb, bool>
 #endif
     {
+        class AsParsable<T> : IParsable<string> where T : IParsable<string>
+        {
+            public static string Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out string result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsSpanParsable<T> : ISpanParsable<string> where T : ISpanParsable<string>
+        {
+            public static string Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out string result) => T.TryParse(s, provider, out result);
+        
+            public static string Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out string result) => T.TryParse(s, provider, out result);
+        }
+
         readonly string value;
 
         public string AsPrimitive() => value;

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.Cc.g.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.Cc.g.cs
@@ -33,6 +33,27 @@ namespace FileGenerate
         , IUtf8SpanFormattable
 #endif
     {
+        class AsParsable<T> : IParsable<int> where T : IParsable<int>
+        {
+            public static int Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsSpanParsable<T> : ISpanParsable<int> where T : ISpanParsable<int>
+        {
+            public static int Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        
+            public static int Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out int result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsUtf8SpanParsable<T> : IUtf8SpanParsable<int> where T : IUtf8SpanParsable<int>
+        {
+            public static int Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => T.Parse(utf8Text, provider);
+            public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out int result) => T.TryParse(utf8Text, provider, out result);
+        }
+
         readonly int value;
 
         public int AsPrimitive() => value;
@@ -94,11 +115,11 @@ namespace FileGenerate
 
 #if NET6_0_OR_GREATER
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => 
-            ((ISpanFormattable)value).TryFormat(destination, out charsWritten, format, provider);
+            value.TryFormat(destination, out charsWritten, format, provider);
 #endif
 #if NET8_0_OR_GREATER        
         public bool TryFormat (Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider) =>
-            ((IUtf8SpanFormattable)value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+            value.TryFormat(utf8Destination, out bytesWritten, format, provider);
 #endif
 
         // UnitGenerateOptions.ArithmeticOperator

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.D.g.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/FileGenerate.D.g.cs
@@ -19,12 +19,29 @@ namespace FileGenerate
 #endif
 #if NET7_0_OR_GREATER
         , IComparisonOperators<D, D, bool>
+        , IParsable<D>
+        , ISpanParsable<D>
 #endif
 #if NET8_0_OR_GREATER
         , IEqualityOperators<D, D, bool>
         , IUtf8SpanFormattable
 #endif
     {
+        class AsParsable<T> : IParsable<System.Guid> where T : IParsable<System.Guid>
+        {
+            public static System.Guid Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out System.Guid result) => T.TryParse(s, provider, out result);
+        }
+
+        class AsSpanParsable<T> : ISpanParsable<System.Guid> where T : ISpanParsable<System.Guid>
+        {
+            public static System.Guid Parse (string s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse (string? s, IFormatProvider? provider, out System.Guid result) => T.TryParse(s, provider, out result);
+        
+            public static System.Guid Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => T.Parse(s, provider);
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out System.Guid result) => T.TryParse(s, provider, out result);
+        }
+
         readonly System.Guid value;
 
         public System.Guid AsPrimitive() => value;
@@ -125,6 +142,48 @@ namespace FileGenerate
                 return false;
             }
         }
+
+#if NET7_0_OR_GREATER
+        public static D Parse(string s, IFormatProvider? provider)
+        {
+            return new D(AsParsable<System.Guid>.Parse(s, provider));
+        }
+ 
+        public static bool TryParse(string s, IFormatProvider? provider, out D result)
+        {
+            if (AsParsable<System.Guid>.TryParse(s, provider, out var r))
+            {
+                result = new D(r);
+                return true;
+            }
+            else
+            {
+                result = default(D);
+                return false;
+            }
+        }
+#endif
+
+#if NET7_0_OR_GREATER
+        public static D Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
+        {
+            return new D(AsSpanParsable<System.Guid>.Parse(s, provider));
+        }
+ 
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out D result)
+        {
+            if (AsSpanParsable<System.Guid>.TryParse(s, provider, out var r))
+            {
+                result = new D(r);
+                return true;
+            }
+            else
+            {
+                result = default(D);
+                return false;
+            }
+        }
+#endif
 
         // UnitGenerateOptions.Comparable
 


### PR DESCRIPTION
`ISpanParsable<Guid.>Parse` cannot be called because Guid is explicily implemented `ISpanParsable`.
In #44,  so we stopped generate it.

However, It can call the `Guid.Parse` implementation by defining `class Proxy<T> where T : IParsable<Guid>` and use as `Proxy<Guid>`.

This PR try to implement it and support Parse of Guid.
