### PR TITLE
add UUIDv7 generation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ namespace UnitGenerator
         {
             this.Type = typeof(T);
             this.Options = options;
-        }
-    }
+        }
+    }
 #endif
 }
 ```
@@ -548,6 +548,21 @@ public readonly partial struct UserId
 
 // setup handler manually
 builder.HasConversion(new UserId.UserIdValueConverter());
+```
+
+### UUIDv7
+
+Implements `New()` method as `Guid.CreateVersion7()`, which was introduced in .NET 9.0. This implementation only takes effect when the Guid type is specified. Even if Guid is specified, a compilation error will occur if the .NET version is below 9.0.
+
+```csharp
+[UnitOf<Guid>(UnitGenerateOptions.UUIDv7)]
+public readonly partial struct Guidv7
+{
+    public static Guidv7 New()
+    {
+        return new Guidv7(Guid.CreateVersion7());
+    }
+}
 ```
 
 ## Use for Unity

--- a/UnitGenerator.sln
+++ b/UnitGenerator.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FileGenerate", "sandbox\Fil
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkApp", "src\EntityFrameworkApp\EntityFrameworkApp.csproj", "{51AE7857-4223-40FE-AEA9-F0E64C5F8238}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitGenerator.NET9.Tests", "tests\UnitGenerator.NET9.Tests\UnitGenerator.NET9.Tests.csproj", "{6E72A93A-938D-4A0C-B2C5-E035A597C232}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{51AE7857-4223-40FE-AEA9-F0E64C5F8238}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51AE7857-4223-40FE-AEA9-F0E64C5F8238}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51AE7857-4223-40FE-AEA9-F0E64C5F8238}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E72A93A-938D-4A0C-B2C5-E035A597C232}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E72A93A-938D-4A0C-B2C5-E035A597C232}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E72A93A-938D-4A0C-B2C5-E035A597C232}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E72A93A-938D-4A0C-B2C5-E035A597C232}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{5DA06D43-A023-4464-B856-8BB42E8E4A05} = {187FBF64-D2AA-444D-AFB1-CE999BC6AD34}
 		{F8353A7A-290E-41D7-A6F8-8D8DBDD44433} = {34EB4113-923D-4855-979C-A0467461B75C}
 		{51AE7857-4223-40FE-AEA9-F0E64C5F8238} = {34EB4113-923D-4855-979C-A0467461B75C}
+		{6E72A93A-938D-4A0C-B2C5-E035A597C232} = {187FBF64-D2AA-444D-AFB1-CE999BC6AD34}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A64DF779-7829-414F-9E6E-3AF349486508}

--- a/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/UnitOfAttribute.cs
+++ b/sandbox/Generated/UnitGenerator/UnitGenerator.SourceGenerator/UnitOfAttribute.cs
@@ -59,6 +59,7 @@ namespace UnitGenerator
         WithoutComparisonOperator = 1 << 11,
         JsonConverterDictionaryKeySupport = 1 << 12,
         Normalize = 1 << 13,
+        UUIDv7 = 1 << 14,
     }
 
     [Flags]

--- a/src/UnitGenerator/SourceGenerator.cs
+++ b/src/UnitGenerator/SourceGenerator.cs
@@ -186,6 +186,7 @@ namespace UnitGenerator
         WithoutComparisonOperator = 1 << 11,
         JsonConverterDictionaryKeySupport = 1 << 12,
         Normalize = 1 << 13,
+        UUIDv7 = 1 << 14,
     }
 
     [Flags]
@@ -546,12 +547,12 @@ namespace {{ns}}
 
         public static {{unitTypeName}} New()
         {
-            return new {{unitTypeName}}(Guid.NewGuid());
+            return new {{unitTypeName}}({{(prop.HasFlag(UnitGenerateOptions.UUIDv7) ? "Guid.CreateVersion7()" : "Guid.NewGuid()")}});
         }
 
         public static {{unitTypeName}} New{{unitTypeName}}()
         {
-            return new {{unitTypeName}}(Guid.NewGuid());
+            return new {{unitTypeName}}({{(prop.HasFlag(UnitGenerateOptions.UUIDv7) ? "Guid.CreateVersion7()" : "Guid.NewGuid()")}});
         }
 
 """);

--- a/src/UnitGenerator/UnitGenerateOptions.cs
+++ b/src/UnitGenerator/UnitGenerateOptions.cs
@@ -21,6 +21,7 @@ namespace UnitGenerator
         WithoutComparisonOperator = 1 << 11,
         JsonConverterDictionaryKeySupport = 1 << 12,
         Normalize = 1 << 13,
+        UUIDv7 = 1 << 14,
     }
 
     [Flags]

--- a/tests/UnitGenerator.NET9.Tests/GuidTests.cs
+++ b/tests/UnitGenerator.NET9.Tests/GuidTests.cs
@@ -1,0 +1,39 @@
+﻿using FluentAssertions;
+using System;
+
+namespace UnitGenerator.NET9.Tests;
+
+public class GuidTests
+{
+    [Fact]
+    public void Guidv7_v4_Comparison_AsExpected()
+    {
+        // v7
+        TryGetUuidV7Timestamp(Guidv7.New().AsPrimitive(), out var v).Should().BeTrue();
+        // ...approximate check
+        v?.ToString("yyyyMMdd").Should().Be(DateTime.UtcNow.ToString("yyyyMMdd"));
+        // v4
+        TryGetUuidV7Timestamp(GuidDefault.New().AsPrimitive(), out var _).Should().BeFalse();
+    }
+
+    static bool TryGetUuidV7Timestamp(Guid uuid, out DateTimeOffset? timestamp)
+    {
+        timestamp = null;
+        var uuidString = uuid.ToString("N");
+        // version number is the 13th character
+        if (uuidString[12] == '7')
+        {
+            var timestampHex = uuidString.Substring(0, 12);
+            var milliseconds = Convert.ToInt64(timestampHex, 16);
+            timestamp = DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
+            return true;
+        }
+        else return false;
+    }
+}
+
+[UnitOf<Guid>(UnitGenerateOptions.UUIDv7)]
+public readonly partial struct Guidv7 { }
+
+[UnitOf<Guid>()]
+public readonly partial struct GuidDefault { }

--- a/tests/UnitGenerator.NET9.Tests/UnitGenerator.NET9.Tests.csproj
+++ b/tests/UnitGenerator.NET9.Tests/UnitGenerator.NET9.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\UnitGenerator\UnitGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+	<ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Changes:
- Implements UUIDv7 generation using `Guid.CreateVersion7()` (.NET 9.0 feature)
- Adds corresponding unit tests
- Updates documentation

Note: Using `[UnitOf<Guid>(UnitGenerateOptions.UUIDv7)]` requires .NET 9.0 or higher.
Compilation will fail on earlier .NET versions. Currently, there's no backward 
compatibility solution implemented.